### PR TITLE
move babel-polyfill to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
     "url": "https://github.com/s00d/webpack-shell-plugin-next/issues"
   },
   "homepage": "https://github.com/s00d/webpack-shell-plugin-next",
+  "dependencies": {
+    "babel-polyfill": "^6.26.0"
+  }
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",
-    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "css-loader": "^0.23.1",
     "eslint": "^2.7.0",


### PR DESCRIPTION
if i not installed babel-polyfill in my project there is an error occurred
`Error: Cannot find module 'babel-polyfill'`