### PR TITLE
Fix invalid JSON in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/s00d/webpack-shell-plugin-next",
   "dependencies": {
     "babel-polyfill": "^6.26.0"
-  }
+  },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",


### PR DESCRIPTION
RE: #4. we can't install from the master branch as it is now because of a syntax error in the json.