### PR TITLE
Add option to run tasks before normal run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ module.exports = {
 
 ***Default: ```{scripts: [],blocking: false,parallel: false}```***
 
+* `onBeforeNormalRun`: configuration object for scripts that execute on normal run without --watch option
+
+***Default: ```{scripts: [],blocking: false,parallel: false}```***
+
 * `blocking (onBeforeBuild, onBuildStart, onBuildEnd, onBuildExit, onBuildExit, onWatchRun)`: block webpack until scripts finish execution.
 * `parallel (onBeforeBuild, onBuildStart, onBuildEnd, onBuildExit, onBuildExit, onWatchRun)`: execute scripts in parallel, otherwise execute scripts in the order in which they are specified in the scripts array.
 * `env`: Object with environment variables that will be applied to the executables **Default: { }**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,6 +6,7 @@
 import { Options } from './types';
 import * as webpack from 'webpack';
 export default class WebpackShellPlugin {
+    private onBeforeNormalRun;
     private onBeforeBuild;
     private onBuildStart;
     private onBuildEnd;
@@ -28,6 +29,7 @@ export default class WebpackShellPlugin {
     private handleScriptAsync;
     private executeScripts;
     apply(compiler: webpack.Compiler): void;
+    private readonly onBeforeRun;
     private readonly afterCompile;
     private readonly onInvalid;
     private readonly onCompilation;

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,29 @@ var WebpackShellPlugin = /** @class */ (function () {
         this.safe = false;
         this.logging = true;
         this.swallowError = false;
+        this.onBeforeRun = function (compiler, callback) { return __awaiter(_this, void 0, void 0, function () {
+            var onBeforeNormalRun;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        onBeforeNormalRun = this.onBeforeNormalRun;
+                        if (!(onBeforeNormalRun.scripts && onBeforeNormalRun.scripts.length > 0)) return [3 /*break*/, 2];
+                        this.log('Executing pre-run scripts');
+                        return [4 /*yield*/, this.executeScripts(onBeforeNormalRun.scripts, onBeforeNormalRun.parallel, onBeforeNormalRun.blocking)];
+                    case 1:
+                        _a.sent();
+                        if (this.dev) {
+                            this.onDoneWatch = JSON.parse(JSON.stringify(defaultTask));
+                        }
+                        _a.label = 2;
+                    case 2:
+                        if (callback) {
+                            callback();
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        }); };
         this.afterCompile = function (compilation, callback) { return __awaiter(_this, void 0, void 0, function () {
             var onDoneWatch;
             return __generator(this, function (_a) {
@@ -209,6 +232,7 @@ var WebpackShellPlugin = /** @class */ (function () {
             this.warn("WebpackShellPlugin [" + new Date() + "]: Verbose is being deprecated, please remove.");
         }
         this.onBeforeBuild = this.validateEvent(options.onBeforeBuild);
+        this.onBeforeNormalRun = this.validateEvent(options.onBeforeNormalRun);
         this.onBuildStart = this.validateEvent(options.onBuildStart);
         this.onBuildEnd = this.validateEvent(options.onBuildEnd);
         this.onBuildExit = this.validateEvent(options.onBuildExit);
@@ -231,6 +255,7 @@ var WebpackShellPlugin = /** @class */ (function () {
             this.swallowError = options.swallowError;
         }
         this.onCompilation = this.onCompilation.bind(this);
+        this.onBeforeRun = this.onBeforeRun.bind(this);
         this.onAfterEmit = this.onAfterEmit.bind(this);
         this.onDone = this.onDone.bind(this);
         this.onInvalid = this.onInvalid.bind(this);
@@ -352,6 +377,7 @@ var WebpackShellPlugin = /** @class */ (function () {
     };
     WebpackShellPlugin.prototype.apply = function (compiler) {
         if (compiler.hooks) {
+            compiler.hooks.beforeRun.tapAsync('webpack-shell-plugin-next', this.onBeforeRun);
             compiler.hooks.invalid.tap('webpack-shell-plugin-next', this.onInvalid);
             compiler.hooks.compilation.tap('webpack-shell-plugin-next', this.onCompilation);
             compiler.hooks.afterEmit.tapAsync('webpack-shell-plugin-next', this.onAfterEmit);
@@ -360,6 +386,7 @@ var WebpackShellPlugin = /** @class */ (function () {
             compiler.hooks.watchRun.tapAsync('webpack-shell-plugin-next', this.watchRun);
         }
         else {
+            compiler.plugin('before-run', this.onBeforeRun);
             compiler.plugin('invalid', this.onInvalid);
             compiler.plugin('compilation', this.onCompilation);
             compiler.plugin('after-emit', this.onAfterEmit);

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -9,6 +9,8 @@ export declare type Script = {
     args: string[];
 };
 export declare type Options = {
+    /** Scripts to execute before normal run (without --watch). Defaults to []. */
+    onBeforeNormalRun?: Tasks | string;
     /** Scripts to execute on the before build. Defaults to []. */
     onBeforeBuild?: Tasks | string;
     /** Scripts to execute on the initial build. Defaults to []. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type Script = {
 };
 
 export type Options = {
+    /** Scripts to execute before normal run (without --watch). Defaults to []. */
+    onBeforeNormalRun?: Tasks|string
     /** Scripts to execute on the before build. Defaults to []. */
     onBeforeBuild?: Tasks|string
     /** Scripts to execute on the initial build. Defaults to []. */

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -23,6 +23,14 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new WebpackShellPlugin({
+            onBeforeNormalRun: {
+              scripts: [
+                'echo "onBeforeRun"',
+                'sleep 1'
+              ],
+              blocking: true,
+              parallel: false
+            },
             onBuildStart: {
               scripts: [
                 'echo "onBuildStart"',
@@ -94,7 +102,7 @@ const config: webpack.Configuration = {
                 parallel: false,
                 blocking: true,
             },
-            dev: true,
+            dev: false,
             safe: false,
             logging: true
         }),


### PR DESCRIPTION
This allows a configuration of run before every watch rebuild with
`onWatchRun` and before a normal build (with the new `onBeforeNormalRun`). The other options otherwise conflict and cause a lot of executions.

During normal `webpack` run:

![image](https://user-images.githubusercontent.com/6438760/80829220-01ac5980-8be7-11ea-879f-5801ef1fc0fc.png)

During watch mode:

![image](https://user-images.githubusercontent.com/6438760/80829240-0bce5800-8be7-11ea-8517-35cf3132208b.png)
